### PR TITLE
feat: change deployment model to deploy-pages action

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,20 +1,19 @@
 name: Publish docs via GitHub Pages
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
+  pull_request:
+    branches: [ master ]
 
 jobs:
   checks:
-    if: github.event_name != 'push'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '23.x'
       - name: Test Build
@@ -23,14 +22,14 @@ jobs:
           npm run build
 
   gh-release:
-    if: github.event_name != 'pull_request'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '23.x'
-      - uses: webfactory/ssh-agent@v0.5.0
+      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}
       - name: Release to GitHub Pages

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -7,37 +7,40 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+  pages: write # to deploy to Pages
+  id-token: write # to verify the deployment originates from an appropriate source
+# deploy-pages can fail or race if two deployments to the same Pages environment run at once
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  checks:
-    if: github.event_name == 'pull_request'
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '23.x'
-      - name: Test Build
+      - name: Build
         run: |
           yarn install --frozen-lockfile
           npm run build
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        if: github.ref == 'refs/heads/master'
+        with:
+          path: build
 
-  gh-release:
+  deploy:
     if: github.ref == 'refs/heads/master'
+    needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '23.x'
-      - uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
-        with:
-          ssh-private-key: ${{ secrets.GH_PAGES_DEPLOY }}
-      - name: Release to GitHub Pages
-        env:
-          USE_SSH: true
-          GIT_USER: git
-        run: |
-          git config --global user.email "doc@tributech.io"
-          git config --global user.name "Documentation"
-          yarn install --frozen-lockfile
-          npm run deploy
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ This command generates static content into the `build` directory and can be serv
 
 ## Deployment
 
-Pushing to master triggers the `Publish docs via GitHub Pages` workflow. Its `gh-release` job builds the site and runs `docusaurus deploy`, which pushes the build output to the `gh-pages` branch using the SSH deploy key stored in repo secrets.
+Pushing to master triggers the `Publish docs via GitHub Pages` workflow. The `build` job builds the site, and the `deploy` job publishes the build output straight to GitHub Pages using GitHub's native Actions deployment, authenticated via the workflow's own token.
 
-GitHub Pages is set to serve from the `gh-pages` branch. Every push to that branch is picked up automatically by GitHub's own Pages build system, which publishes the content live at docs.tributech.io.
+The site is live at docs.tributech.io, configured via `static/CNAME`.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ This command generates static content into the `build` directory and can be serv
 
 ## Deployment
 
-The master branch get automatically deployed using Github-Actions.
+Pushing to master triggers the `Publish docs via GitHub Pages` workflow. Its `gh-release` job builds the site and runs `docusaurus deploy`, which pushes the build output to the `gh-pages` branch using the SSH deploy key stored in repo secrets.
+
+GitHub Pages is set to serve from the `gh-pages` branch. Every push to that branch is picked up automatically by GitHub's own Pages build system, which publishes the content live at docs.tributech.io.
 
 ## Versioning
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,7 @@ export default {
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.png',
   organizationName: 'tributech-solutions',
-  projectName: 'tributech-dsk-docs',
+  projectName: 'tributech-docs',
   themeConfig: {
     navbar: {
       title: 'Tributech Documentation',
@@ -108,7 +108,7 @@ export default {
           includeCurrentVersion: false,
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl:
-            'https://github.com/tributech-solutions/tributech-dsk-docs/edit/master/',
+            'https://github.com/tributech-solutions/tributech-docs/edit/master/',
         },
         blog: false,
         theme: {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
-    "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",


### PR DESCRIPTION
## Summary
Replaces the legacy SSH-based deployment with GitHub's official Pages deployment flow (`actions/upload-pages-artifact` + `actions/deploy-pages`). See the action: https://github.com/actions/deploy-pages 

## Changes
- **New deployment model**: `build` job compiles the site and uploads the `build/` output as a Pages artifact; `deploy` job (gated to `master`, `needs: build`) publishes it via `actions/deploy-pages`. No more SSH key (`GH_PAGES_DEPLOY` secret) or `gh-pages` branch push.
- **Permissions**: `pages: write` (deploy to Pages), `id-token: write` (OIDC token so GitHub can verify the deployment source), `contents: read`.
- **`environment: github-pages`**: required for `deploy-pages` to issue its OIDC token; also enables deployment tracking/protection rules and the live URL output.
- **Concurrency guard**: `pages` group (`cancel-in-progress: false`) since `deploy-pages` can race or fail if two deployments run simultaneously.
- **Action pinning**: `checkout`, `setup-node`, `upload-pages-artifact`, `deploy-pages` pinned to full commit SHA (latest release) with `# vX.Y.Z` comment.
- **Trigger conditions**: build/test runs on `pull_request`; deploy gated on `github.ref == 'refs/heads/master'`.

## Preparation done
Github Actions deployment mode is selected in the repo settings, the CNAME record on cloudflare is set